### PR TITLE
Add OpenBSD Countries Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   * [Mastodon](#mastodon)
   * [Interviews with OpenBSD developers](#interviews-with-OpenBSD-developers)
   * [Blogs](#blogs)
+  * [OpenBSD Countries Communities](#openbsd-countries-communities)
 * [Selected articles](#selected-articles)
 * [Third party repositories](#third-party-repositories)
 * [OpenBSD Provisioning](#openbsd-provisioning)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@
 * Antoine Jacoutot (ajacoutot@) [beastie.pl](https://web.archive.org/web/20160304052709/http://beastie.pl/deweloperzy-openbsd-antoine-jacoutot/)
 * Stefan Sperling (stsp@) [beastie.pl](https://web.archive.org/web/20160304044753/http://beastie.pl/deweloperzy-openbsd-stefan-sperling/)
 
+
+## OpenBSD Countries Communities
+
+* [OpenBSD Brazil](https://openbsd-br.org) - https://openbsd-br.org
+
+
 ## Selected articles
 
 * [Keeping Your OpenBSD System In Trim: A Works For Me Guide](http://bsdly.blogspot.com/2012/07/keeping-your-openbsd-system-in-trim.html)

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@
 
 ## OpenBSD Countries Communities
 
-* [OpenBSD Brazil](https://openbsd-br.org) - https://openbsd-br.org
+* [OpenBSD Brazil](https://openbsd-br.org)
 
 
 ## Selected articles


### PR DESCRIPTION
- Add "OpenBSD Countries Communities" to the index;
- Adds the OpenBSD Brazil website under this section;

cc: @ligurio 