### PR TITLE
Add BSDCan link to conferences section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@
 - [EuroBSDCon](https://eurobsdcon.org/)
 - [NYCBSDCon](https://www.nycbsdcon.org/)
 - [AsiaBSDCon](https://asiabsdcon.org)
+- [BSDCan](https://www.bsdcan.org/)
 - [vBSDCon](https://www.verisign.com/en_US/internet-technology-news/verisign-events/vbsdcon/index.xhtml)
 - [OpenKyiv](https://www.uaoug.org.ua/openkyiv/)
 - [BSDTW](https://bsdtw.org/)


### PR DESCRIPTION
BSDCan usually has many OpenBSD talks and tutorials, thought I'd add it :slightly_smiling_face: 