### PR TITLE
Add FuguIta: Live OpenBSD system

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - `opensource` [Bitrig](https://www.bitrig.org/)
 - `opensource` [reflash](https://stable.rcesoftware.com/resflash/)
 - `opensource` [OpenBSD Flashboot](https://github.com/kirei/flashboot)
+- `opensource` [FuguIta](http://fuguita.org/) is a live system based on OpenBSD that is designed to run from removable media. Note a portion of documentation is only available in Japanese.
 
 ## Hosting
 


### PR DESCRIPTION
_FuguIta_ is a Live System based on OpenBSD that is designed to be run
from removable media: http://fuguita.org/.

A large portion of developer documentation is in Japanese so I've made
a note of that as well.