### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2
+  - 2.4
 
 before_script:
   - gem install awesome_bot


### PR DESCRIPTION
As noted in https://travis-ci.org/github/ligurio/awesome-openbsd/builds/769979729
```
$ gem install awesome_bot
Fetching: parallel-1.20.1.gem (100%)
ERROR:  Error installing awesome_bot:
	parallel requires Ruby version >= 2.4.
```