### PR TITLE
remove securityrouter.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@
 - `closed-source` [ATMNIS](https://atmnis.com/) - первая и единственная UNIX-подобная защищённая операционная система в Украине, сертифицированная к использованию при создании комплексных систем защиты информации (КСЗИ) классов 2 и 3. See [slides](https://www.atmnis.com/~apelsin/papers/).
 - `closed-source` [Calyptix Security](https://www.calyptix.com/products/models/) - firewall to protect and manage SMB networks. See [slides](http://www.nycbsdcon.org/2010/presentations/lteo-nycbsdcon2010.pdf).
 - `closed-source` [M:Tier](https://www.mtier.org/about-us/): OpenBSD thin client ([slides](http://www.mtier.org/assets/Uploads/latinoware-2013.pdf)), OpenBSD enterprise desktop for Fortune 500 companies ([slides](http://www.openbsd.org/papers/opencon07-gnome.pdf) and [article](http://undeadly.org/cgi?action=article&sid=20110420080633)), [Long Term Support subscription](https://stable.mtier.org/subscriptions).
-- `opensource` [Security Router](https://securityrouter.org/wiki/Main_Page)
 - `opensource` [MirOS](https://www.mirbsd.org/)
 - `opensource` [Bitrig](https://www.bitrig.org/)
 - `opensource` [reflash](https://stable.rcesoftware.com/resflash/)


### PR DESCRIPTION
Remove securityrouter.org from *OpenBSD-based projects*

The project has been discontinued and security patches are unavailable after 2022-01-01. See https://web.archive.org/web/20210309235325/https://securityrouter.org/wiki/Main_Page

and

https://web.archive.org/web/20220619090722/https://securityrouter.org/

or

https://archive.ph/tkWTG