### PR TITLE
rename prgmr.com to TornadoVPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
 * `kvm` [Data Center Light](https://twitter.com/reykfloeter/status/1146714795552509952)
 * `xen` [Amazon EC2](https://gist.github.com/reyk/b372af303eb86bab3fee#file-openbsd-amd64-20160809-aws)
 * `xen` [AWS-OpenBSD](https://github.com/ajacoutot/aws-openbsd) - AWS playground for OpenBSD kids
-* `xen` [prgmr.com](https://prgmr.com/xen/) ([How-To Setup](https://wiki.prgmr.com/mediawiki/index.php/OpenBSD))
+* `xen` [TornadoVPS](https://tornadovps.com/) ([How-To Setup](https://tornadovps.com/documentation/openbsd))(formerly prgmr.com)
 * `hyper-v` [Azure Devops](https://gist.github.com/reyk/f6d2c7b9567cae7b4270)
 * `shell` [Devio.us](https://devio.us/)
 * `shell` [Polarhome](https://www.polarhome.com/)

--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@
 * https://github.com/elad/openbsd-apu2
 * https://github.com/cullum/dank-selfhosted
 * https://github.com/codeghar/openbsd-on-erl
-* [desktop-openbsd-starter-kit](https://github.com/matthewgraybosch/desktop-openbsd-starter-kit) - Dotfiles and config files for use with OpenBSD on a desktop or laptop
 * [vedetta](https://github.com/vedetta-com/vedetta) - OpenBSD Router Boilerplate
 * [caesonia](https://github.com/vedetta-com/caesonia) - OpenBSD Email Service (there's also a [Playbook for Caesonia](https://github.com/vedetta-com/ansible-role-caesonia))
 * [dotfiles, sweet dotfiles](https://github.com/unbalancedparentheses/dotfiles)


### PR DESCRIPTION
prgmr.com changed their name to TornadoVPS in March 2022.

https://web.archive.org/web/20220317044355/https://tornadovps.com/blog/2022/03/16/tornado-vps