### PR TITLE
CI: add GiHub action cross-platform-actions/action

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [Sourcehut](https://man.sr.ht/builds.sr.ht/compatibility.md#openbsd) - OpenBSD, FreeBSD and NetBSD support
 - GitLab ([HowTo](https://frankgroeneveld.nl/2016/04/06/using-gitlab-ci-multi-runner-on-openbsd/)), [sysutils/gitlab-runner](http://openbsd-archive.7691.n7.nabble.com/new-sysutils-gitlab-runner-td365939.html#a365948)
 - GitHub action [vmactions/openbsd-vm](https://github.com/vmactions/openbsd-vm)
+- GitHub action [cross-platform-actions/action](https://github.com/cross-platform-actions/action) - OpenBSD, FreeBSD and NetBSD support
 - Travis CI ([Running FreeBSD in Travis-CI](https://erouault.blogspot.com/2016/09/running-freebsd-in-travis-ci.html))
 - MinCI https://github.com/kristapsdz/minci
 


### PR DESCRIPTION
GitHub action with support for OpenBSD, NetBSD and FreeBSD